### PR TITLE
Implemented sendMultiple() method to send multiple messages with 1 API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This extension allow the developper to use [Mailjet](https://www.mailjet.com/) a
 Installation
 ------------
 
-If you use Packagist for installing packages, then you can update your composer.json like this :
+If you use composer for installing packages, then you can update your composer.json like this:
 
 ``` json
 {
@@ -28,24 +28,32 @@ If you use Packagist for installing packages, then you can update your composer.
 }
 ```
 
-Howto use it
+or use the command:
+
+```
+composer require sweelix/yii2-mailjet
+```
+
+How to use it
 ------------
 
-Add extension to your configuration
+Add extension to your configuration:
 
 ``` php
 return [
-    //....
+    // ...
     'components' => [
         'mailer' => [
             'class' => 'sweelix\mailjet\Mailer',
-            'token' => '<your mailjet token>',
+            'apiKey' => '<your mailjet api key>',
+            'apiSecret' => '<your mailjet api secret>',
         ],
     ],
+    // ...
 ];
 ```
 
-You can send email as follow (using mailjet templates)
+You can send email as follows (using mailjet templates):
 
 ``` php
 Yii::$app->mailer->compose('contact/html')
@@ -60,13 +68,45 @@ Yii::$app->mailer->compose('contact/html')
 
 ```
 
+You can send multiple emails with only one API call as follows:
+
+``` php
+$messages = [];
+$messages[] = Yii::$app->mailer->compose()
+     ->setFrom('from@domain.com')
+     ->setTo(recipient2@example.org)
+     ->setSubject($form->subject)
+     ->setTemplateId(1234);
+
+$messages[] = Yii::$app->mailer->compose()
+     ->setFrom('from@domain.com')
+     ->setTo('recipient2@example.org')
+     ->setSubject($form->subject)
+     ->setTemplateId(1234);
+
+// add more messages as needed, but be aware of MailJet's limit of max. 50 recipients (email addresses?) per API call
+
+// option 1: call sendMultiple(), returns number of successfully sent messages
+$successCount = Yii::$app->mailer->sendMultiple($messages);
+// Mailer->apiResponse contains the last API response as \Mailjet\Response object, with detailed info for every (sent or failed) message
+$apiResponse = Yii::$app->mailer->apiResponse;
+
+
+// option 2: call sendMultiple() passing true as second parameter, directly returns \Mailjet\Response object
+$apiResponse = Yii::$app->mailer->sendMultiple($messages, true);
+```
+
+Use the methods `$message->setTextBody($text)` and `$message->setHtmlBody($html)` to set the email content directly, without using a MailJet template.
+
 For further instructions refer to the [related section in the Yii Definitive Guide](http://www.yiiframework.com/doc-2.0/guide-tutorial-mailing.html)
 
 
 Running the tests
 -----------------
 
-Before running the tests, you should edit the file tests/_bootstrap.php and change the defines :
+Please note that the tests need PHPUnit 5 to run.
+
+Before running the tests, you should edit the file tests/_bootstrap.php and change the defines:
 
 ``` php
 // ...

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -74,83 +74,6 @@ class Mailer extends BaseMailer
      */
     public $messageClass = 'sweelix\mailjet\Message';
 
-    /**
-     * @param \sweelix\mailjet\Message $message
-     * @return array message as array that the MailJet API expects
-     */
-    protected function getMailJetMessage($message)
-    {
-        $fromEmails = Message::convertEmails($message->getFrom());
-        $toEmails = Message::convertEmails($message->getTo());
-
-        $mailJetMessage = [
-            'From' => $fromEmails[0],
-            'To' => $toEmails,
-        ];
-        /*
-        if (isset($fromEmails[0]['Name']) === true) {
-            $mailJetMessage['FromName'] = $fromEmails[0]['Name'];
-        }
-        */
-
-        /*
-        $sender = $message->getSender();
-        if (empty($sender) === false) {
-            $sender = Message::convertEmails($sender);
-            $mailJetMessage['Sender'] = $sender[0];
-        }
-        */
-
-        $cc = $message->getCc();
-        if (empty($cc) === false) {
-            $cc = Message::convertEmails($cc);
-            $mailJetMessage['Cc'] = $cc;
-        }
-
-        $bcc = $message->getBcc();
-        if (empty($cc) === false) {
-            $bcc = Message::convertEmails($bcc);
-            $mailJetMessage['Bcc'] = $bcc;
-        }
-
-        $attachments = $message->getAttachments();
-        if ($attachments !== null) {
-            $mailJetMessage['Attachments'] = $attachments;
-        }
-
-        $headers = $message->getHeaders();
-        if (empty($headers) === false) {
-            $mailJetMessage['Headers'] = $headers;
-        }
-        $mailJetMessage['TrackOpens'] = $message->getTrackOpens();
-        $mailJetMessage['TrackClicks'] = $message->getTrackClicks();
-
-        $templateModel = $message->getTemplateModel();
-        if (empty($templateModel) === false) {
-            $mailJetMessage['Variables'] = $templateModel;
-        }
-
-        $templateId = $message->getTemplateId();
-        if ($templateId === null) {
-            $mailJetMessage['Subject'] = $message->getSubject();
-            $textBody = $message->getTextBody();
-            if (empty($textBody) === false) {
-                $mailJetMessage['TextPart'] = $textBody;
-            }
-            $htmlBody = $message->getHtmlBody();
-            if (empty($htmlBody) === false) {
-                $mailJetMessage['HTMLPart'] = $htmlBody;
-            }
-        } else {
-            $mailJetMessage['TemplateID'] = $templateId;
-            $processLanguage = $message->getTemplateLanguage();
-            if ($processLanguage === true) {
-                $mailJetMessage['TemplateLanguage'] = $processLanguage;
-            }
-        }
-
-        return $mailJetMessage;
-    }
 
     /**
      * Sends the specified message.
@@ -167,8 +90,8 @@ class Mailer extends BaseMailer
 
     /**
      * Sends multiple messages at once.
-     * @param array $messages list of email messages, which should be sent.
-     * @param boolean $returnResponse whether to return the count of successfully sent messages or MailJet's response body
+     * @param Message[] $messages list of email messages, which should be sent.
+     * @param boolean $returnResponse whether to return the count of successfully sent messages or MailJet's response object
      * @return int|\Mailjet\Response number of successfully sent messages, or MailJet's api response if $returnResponse is set to true
      * @throws InvalidConfigException
      */
@@ -176,7 +99,7 @@ class Mailer extends BaseMailer
     {
         $mailJetMessages = [];
         foreach ($messages as $message) {
-            $mailJetMessages[] = $this->getMailJetMessage($message);
+            $mailJetMessages[] = $message->getMailJetMessage();
         }
 
         try {

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -18,8 +18,8 @@ namespace sweelix\mailjet;
 use Mailjet\Client;
 use Mailjet\Resources;
 use yii\base\InvalidConfigException;
+use yii\helpers\ArrayHelper;
 use yii\mail\BaseMailer;
-use Exception;
 
 /**
  * This component allow user to send an email
@@ -31,7 +31,6 @@ use Exception;
  * @link http://www.sweelix.net
  * @package sweelix\mailjet
  * @since XXX
- * @todo implement batch messages using API
  */
 class Mailer extends BaseMailer
 {
@@ -66,16 +65,120 @@ class Mailer extends BaseMailer
     public $secured = true;
 
     /**
+     * @var \Mailjet\Response
+     */
+    public $apiResponse;
+
+    /**
      * @inheritdoc
      */
     public $messageClass = 'sweelix\mailjet\Message';
+
     /**
+     * @param \sweelix\mailjet\Message $message
+     * @return array message as array that the MailJet API expects
+     */
+    protected function getMailJetMessage($message)
+    {
+        $fromEmails = Message::convertEmails($message->getFrom());
+        $toEmails = Message::convertEmails($message->getTo());
+
+        $mailJetMessage = [
+            'From' => $fromEmails[0],
+            'To' => $toEmails,
+        ];
+        /*
+        if (isset($fromEmails[0]['Name']) === true) {
+            $mailJetMessage['FromName'] = $fromEmails[0]['Name'];
+        }
+        */
+
+        /*
+        $sender = $message->getSender();
+        if (empty($sender) === false) {
+            $sender = Message::convertEmails($sender);
+            $mailJetMessage['Sender'] = $sender[0];
+        }
+        */
+
+        $cc = $message->getCc();
+        if (empty($cc) === false) {
+            $cc = Message::convertEmails($cc);
+            $mailJetMessage['Cc'] = $cc;
+        }
+
+        $bcc = $message->getBcc();
+        if (empty($cc) === false) {
+            $bcc = Message::convertEmails($bcc);
+            $mailJetMessage['Bcc'] = $bcc;
+        }
+
+        $attachments = $message->getAttachments();
+        if ($attachments !== null) {
+            $mailJetMessage['Attachments'] = $attachments;
+        }
+
+        $headers = $message->getHeaders();
+        if (empty($headers) === false) {
+            $mailJetMessage['Headers'] = $headers;
+        }
+        $mailJetMessage['TrackOpens'] = $message->getTrackOpens();
+        $mailJetMessage['TrackClicks'] = $message->getTrackClicks();
+
+        $templateModel = $message->getTemplateModel();
+        if (empty($templateModel) === false) {
+            $mailJetMessage['Variables'] = $templateModel;
+        }
+
+        $templateId = $message->getTemplateId();
+        if ($templateId === null) {
+            $mailJetMessage['Subject'] = $message->getSubject();
+            $textBody = $message->getTextBody();
+            if (empty($textBody) === false) {
+                $mailJetMessage['TextPart'] = $textBody;
+            }
+            $htmlBody = $message->getHtmlBody();
+            if (empty($htmlBody) === false) {
+                $mailJetMessage['HTMLPart'] = $htmlBody;
+            }
+        } else {
+            $mailJetMessage['TemplateID'] = $templateId;
+            $processLanguage = $message->getTemplateLanguage();
+            if ($processLanguage === true) {
+                $mailJetMessage['TemplateLanguage'] = $processLanguage;
+            }
+        }
+
+        return $mailJetMessage;
+    }
+
+    /**
+     * Sends the specified message.
      * @param Message $message
      * @since XXX
      * @throws InvalidConfigException
      */
     public function sendMessage($message)
     {
+        $messages = [$message];
+        $result = $this->sendMultiple($messages);
+        return ($result == 1);
+    }
+
+    /**
+     * Sends multiple messages at once.
+     * @param array $messages list of email messages, which should be sent.
+     * @param boolean $returnResponse whether to return the count of successfully sent messages or MailJet's response body
+     * @return int|\Mailjet\Response number of successfully sent messages, or MailJet's api response if $returnResponse is set to true
+     * @throws InvalidConfigException
+     */
+    public function sendMultiple(array $messages, $returnResponse = false)
+    {
+        $mailJetMessages = [];
+        foreach ($messages as $message) {
+            $mailJetMessages[] = $this->getMailJetMessage($message);
+        }
+
         try {
             if ($this->apiKey === null) {
                 throw new InvalidConfigException('API Key is missing');
@@ -94,97 +197,39 @@ class Mailer extends BaseMailer
 
             $client = new Client($this->apiKey, $this->apiSecret, $this->enable, $settings);
 
-            $fromEmails = Message::convertEmails($message->getFrom());
-            $toEmails = Message::convertEmails($message->getTo());
+            $this->apiResponse = $client->post(Resources::$Email, [
+                'body' => [
+                    'Messages' => $mailJetMessages,
+                ]
+            ]);
 
-            $mailJetMessage = [
-                // 'FromEmail' => $fromEmails[0]['Email'],
-                'From' => $fromEmails[0],
-                'To' => $toEmails,
-            ];
-            /*
-            if (isset($fromEmails[0]['Name']) === true) {
-                $mailJetMessage['FromName'] = $fromEmails[0]['Name'];
-            }
-            */
-
-            /*
-            $sender = $message->getSender();
-            if (empty($sender) === false) {
-                $sender = Message::convertEmails($sender);
-                $mailJetMessage['Sender'] = $sender[0];
-            }
-            */
-
-
-            $cc = $message->getCc();
-            if (empty($cc) === false) {
-                $cc = Message::convertEmails($cc);
-                $mailJetMessage['Cc'] = $cc;
-            }
-
-            $bcc = $message->getBcc();
-            if (empty($cc) === false) {
-                $bcc = Message::convertEmails($bcc);
-                $mailJetMessage['Bcc'] = $bcc;
-            }
-
-            $attachments = $message->getAttachments();
-            if ($attachments !== null) {
-                $mailJetMessage['Attachments'] = $attachments;
-            }
-
-            $headers = $message->getHeaders();
-            if (empty($headers) === false) {
-                $mailJetMessage['Headers'] = $headers;
-            }
-            $mailJetMessage['TrackOpens'] = $message->getTrackOpens();
-            $mailJetMessage['TrackClicks'] = $message->getTrackClicks();
-
-            $templateModel = $message->getTemplateModel();
-            if (empty($templateModel) === false) {
-                $mailJetMessage['Variables'] = $templateModel;
-            }
-
-            $templateId = $message->getTemplateId();
-            if ($templateId === null) {
-                $mailJetMessage['Subject'] = $message->getSubject();
-                $textBody = $message->getTextBody();
-                if (empty($textBody) === false) {
-                    $mailJetMessage['TextPart'] = $textBody;
-                }
-                $htmlBody = $message->getHtmlBody();
-                if (empty($htmlBody) === false) {
-                    $mailJetMessage['HTMLPart'] = $htmlBody;
-                }
-                $sendResult = $client->post(Resources::$Email, [
-                    'body' => [
-                        'Messages' => [
-                            $mailJetMessage,
-                        ]
-                    ]
-                ]);
-            } else {
-                $mailJetMessage['TemplateID'] = $templateId;
-                $processLanguage = $message->getTemplateLanguage();
-                if ($processLanguage === true) {
-                    $mailJetMessage['TemplateLanguage'] = $processLanguage;
-                }
-                $sendResult = $client->post(Resources::$Email, [
-                    'body' => [
-                        'Messages' => [
-                            $mailJetMessage,
-                        ]
-                    ]
-                ]);
-            }
             //TODO: handle error codes and log stuff
-            return $sendResult->success();
-        } catch (Exception $e) {
+
+            if ($returnResponse) {
+                return $this->apiResponse;
+            }
+
+            // count successfully sent messages using MailJet's response
+            // the format of the response body is:
+            // ['Messages' => [
+            //     0 => ['Status' => 'success', ...],
+            //     1 => ['Status' => 'success', ...],
+            //     ...
+            // ]]
+            $successCount = 0;
+            $resultBody = $this->apiResponse->getBody();
+            if ( ! empty($resultBody['Messages'])) {
+                $resultStatusColumns = ArrayHelper::getColumn($resultBody['Messages'], 'Status');
+                $statusCounts = array_count_values($resultStatusColumns);
+                if (isset($statusCounts['success'])) {
+                    $successCount = $statusCounts['success'];
+                }
+            }
+
+            return $successCount;
+
+        } catch (InvalidConfigException $e) {
             throw $e;
         }
     }
-
-
-
 }

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -94,6 +94,7 @@ class Mailer extends BaseMailer
      * @param boolean $returnResponse whether to return the count of successfully sent messages or MailJet's response object
      * @return int|\Mailjet\Response number of successfully sent messages, or MailJet's api response if $returnResponse is set to true
      * @throws InvalidConfigException
+     * @todo implement workaround for MailJet's limit of max. 50 recipients (mail addresses?) per API call
      */
     public function sendMultiple(array $messages, $returnResponse = false)
     {

--- a/src/Message.php
+++ b/src/Message.php
@@ -587,6 +587,84 @@ class Message extends BaseMessage
     }
 
     /**
+     * Builds an array that represents the message as the MailJet API expects it
+     * @return array message as array that the MailJet API expects
+     */
+    public function getMailJetMessage()
+    {
+        $fromEmails = Message::convertEmails($this->getFrom());
+        $toEmails = Message::convertEmails($this->getTo());
+
+        $mailJetMessage = [
+            'From' => $fromEmails[0],
+            'To' => $toEmails,
+        ];
+        /*
+        if (isset($fromEmails[0]['Name']) === true) {
+            $mailJetMessage['FromName'] = $fromEmails[0]['Name'];
+        }
+        */
+
+        /*
+        $sender = $this->getSender();
+        if (empty($sender) === false) {
+            $sender = Message::convertEmails($sender);
+            $mailJetMessage['Sender'] = $sender[0];
+        }
+        */
+
+        $cc = $this->getCc();
+        if (empty($cc) === false) {
+            $cc = Message::convertEmails($cc);
+            $mailJetMessage['Cc'] = $cc;
+        }
+
+        $bcc = $this->getBcc();
+        if (empty($cc) === false) {
+            $bcc = Message::convertEmails($bcc);
+            $mailJetMessage['Bcc'] = $bcc;
+        }
+
+        $attachments = $this->getAttachments();
+        if ($attachments !== null) {
+            $mailJetMessage['Attachments'] = $attachments;
+        }
+
+        $headers = $this->getHeaders();
+        if (empty($headers) === false) {
+            $mailJetMessage['Headers'] = $headers;
+        }
+        $mailJetMessage['TrackOpens'] = $this->getTrackOpens();
+        $mailJetMessage['TrackClicks'] = $this->getTrackClicks();
+
+        $templateModel = $this->getTemplateModel();
+        if (empty($templateModel) === false) {
+            $mailJetMessage['Variables'] = $templateModel;
+        }
+
+        $templateId = $this->getTemplateId();
+        if ($templateId === null) {
+            $mailJetMessage['Subject'] = $this->getSubject();
+            $textBody = $this->getTextBody();
+            if (empty($textBody) === false) {
+                $mailJetMessage['TextPart'] = $textBody;
+            }
+            $htmlBody = $this->getHtmlBody();
+            if (empty($htmlBody) === false) {
+                $mailJetMessage['HTMLPart'] = $htmlBody;
+            }
+        } else {
+            $mailJetMessage['TemplateID'] = $templateId;
+            $processLanguage = $this->getTemplateLanguage();
+            if ($processLanguage === true) {
+                $mailJetMessage['TemplateLanguage'] = $processLanguage;
+            }
+        }
+
+        return $mailJetMessage;
+    }
+
+    /**
      * @inheritdoc
      * @todo make real serialization to make message compliant with MailjetAPI
      */
@@ -624,6 +702,7 @@ class Message extends BaseMessage
         }
         return $emails;
     }
+
     public static function convertEmails($emailsData)
     {
         $emails = [];

--- a/src/Message.php
+++ b/src/Message.php
@@ -666,11 +666,10 @@ class Message extends BaseMessage
 
     /**
      * @inheritdoc
-     * @todo make real serialization to make message compliant with MailjetAPI
      */
     public function toString()
     {
-        return serialize($this);
+        return json_encode($this->getMailJetMessage(), JSON_PRETTY_PRINT);
     }
 
 

--- a/tests/unit/MailerTest.php
+++ b/tests/unit/MailerTest.php
@@ -15,6 +15,8 @@
 namespace tests\unit;
 
 use sweelix\mailjet\Mailer;
+use sweelix\mailjet\Message;
+use Yii;
 
 /**
  * Test node basic functions
@@ -47,9 +49,79 @@ class MailerTest extends TestCase
         return $component;
     }
 
+    /**
+     * Method to enable IDE auto-completion in other methods
+     * @return null|Mailer
+     * @throws \yii\base\InvalidConfigException
+     */
+    protected function getYiiMailerComponent()
+    {
+        return Yii::$app->get('mailer');
+    }
+
     public function testGetMailjetMailer()
     {
         $mailer = $this->createTestEmailComponent();
         $this->assertInstanceOf(Mailer::className(), $mailer);
+    }
+
+    /**
+     * @return Message test message instance.
+     */
+    protected function createTestMessage()
+    {
+        return Yii::$app->get('mailer')->compose();
+    }
+
+
+    public function testMultipleSend()
+    {
+        // allow disabling real tests
+        if (MAILJET_TEST_SEND === true) {
+            $mailer = Yii::$app->get('mailer');
+            $messages = [];
+            $numberOfTestMessages = 3;
+            for ($i = 1; $i <= $numberOfTestMessages; $i++) {
+                $message = $this->createTestMessage();
+                $message->setFrom(MAILJET_FROM);
+                $message->setTo(MAILJET_TO);
+                $message->setSubject('Yii MailJet test message: testMultipleSend() - (' . $i . ' of ' . $numberOfTestMessages . ')');
+                $message->setTextBody('Yii MailJet test body: testMultipleSend() - (' . $i . ' of ' . $numberOfTestMessages . ')');
+                $messages[] = $message;
+            }
+            $successCount = $mailer->sendMultiple($messages);
+            $this->assertEquals($numberOfTestMessages, $successCount);
+        }
+    }
+
+    public function testMultipleSendReturnResponseBody()
+    {
+        // allow disabling real tests
+        if (MAILJET_TEST_SEND === true) {
+            $messages = [];
+            $numberOfTestMessages = 3;
+            for ($i = 1; $i <= $numberOfTestMessages; $i++) {
+                $message = $this->createTestMessage();
+                $message->setFrom(MAILJET_FROM);
+                $message->setTo(MAILJET_TO);
+                $message->setSubject('Yii MailJet test message: testMultipleSendReturnResponseBody() -  (' . $i . ' of ' . $numberOfTestMessages . ')');
+                $message->setTextBody('Yii MailJet test body: testMultipleSendReturnResponseBody() - (' . $i . ' of ' . $numberOfTestMessages . ')');
+                $messages[] = $message;
+            }
+
+            $mailer = $this->getYiiMailerComponent();
+            $response = $mailer->sendMultiple($messages, true);
+
+            $this->assertInstanceOf(\Mailjet\Response::class, $response);
+            $this->assertEquals(200, $response->getStatus());
+            $this->assertEquals(true, $response->success());
+
+            $responseBody = $response->getBody();
+            $this->assertArrayHasKey('Messages', $responseBody);
+            $this->assertCount($numberOfTestMessages, $responseBody['Messages']);
+            for ($i = 0; $i < $numberOfTestMessages; $i++) {
+                $this->assertEquals('success', $responseBody['Messages'][$i]['Status']);
+            }
+        }
     }
 }

--- a/tests/unit/MessageTest.php
+++ b/tests/unit/MessageTest.php
@@ -292,10 +292,9 @@ class MessageTest extends TestCase
         if (MAILJET_TEST_SEND === true) {
             $message = $this->createTestMessage();
             $message->setFrom(MAILJET_FROM);
-            // $message->setSender(MAILJET_SENDER);
             $message->setTo(MAILJET_TO);
-            $message->setSubject('Yii MailJet test message');
-            $message->setTextBody('Yii MailJet test body');
+            $message->setSubject('Yii MailJet test message: testBasicSend()');
+            $message->setTextBody('Yii MailJet test body: testBasicSend()');
             $this->assertTrue($message->send());
         }
     }
@@ -306,11 +305,10 @@ class MessageTest extends TestCase
             $message = $this->createOtherTestMessage();
             $message->setFrom(MAILJET_FROM);
             $message->setTo(MAILJET_TO);
-            $message->setSubject('Yii MailJet test message');
-            $message->setTextBody('Yii MailJet test body');
+            $message->setSubject('Yii MailJet test message: testParametersSend()');
+            $message->setTextBody('Yii MailJet test body: testParametersSend()');
             $this->assertTrue($message->send());
         }
-
     }
 
     public function testTemplateSend()


### PR DESCRIPTION
I implemented the `sendMultiple()` method in the `Mailer` class following the convention of `BaseMailer` (but added an optional `$returnResponse` parameter to return the API's response, as that is handy when errors occur while sending multiple mails at once.

I added a `getMailJetMessage()` method to Message to build an array that represents the Message object as the MailJet API expects it.

I also added 2 tests for the new `sendMultiple()` method, everything passes (using PHPUnit).
Also updated the README accordingly.
No backwards-compatibility breaking changes were made.

It's only my second PR, so let me know if I should change anything.
Thanks for the nice component.